### PR TITLE
GitHub Actions: Node.js 20 廃止に伴いアクションを更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@a0853c24544627f65ddf259abe73b1d18a591444  # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
         with:
           path: ./dist
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0 https://github.com/actions/setup-node/releases/tag/v5.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4.0.0 https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0
         with:
           path: ./dist
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0 https://github.com/actions/deploy-pages/releases/tag/v5.0.0

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,0 +1,84 @@
+# KNOWLEDGE
+
+プロジェクト運用で得た知見をまとめる。
+
+---
+
+## GitHub Actions: アクションのコミットハッシュ固定
+
+### なぜハッシュで固定するか
+
+`uses: actions/checkout@v5` のようなタグ指定は mutable（上書き可能）なため、タグを書き換えることでサプライチェーン攻撃が成立する。
+コミットハッシュで固定することでこのリスクを排除できる。
+
+参考: [axios ソフトウェアサプライチェーン攻撃の概要と対応指針 - GMO Flatt Security Blog](https://blog.flatt.tech/entry/axios_compromise)
+
+### ハッシュの取得方法
+
+```bash
+# タグに対応するコミット SHA を1件ずつ取得する（必ず1件ずつ実行する）
+gh api repos/actions/checkout/commits/v5.0.1 --jq '.sha'
+gh api repos/actions/setup-node/commits/v5.0.0 --jq '.sha'
+```
+
+**注意: `&` による並列実行は出力順序が保証されないため使わない。**
+複数を一度に取得したい場合は `echo "ラベル: $(コマンド)"` の形で識別子をつける。
+
+```bash
+# OK: ラベル付きで順次実行
+echo "checkout: $(gh api repos/actions/checkout/commits/v5.0.1 --jq '.sha')"
+echo "setup-node: $(gh api repos/actions/setup-node/commits/v5.0.0 --jq '.sha')"
+```
+
+### ハッシュの検証方法
+
+取得したSHAが正しいか、以下のいずれかで確認する。
+
+```bash
+# タグ一覧から逆引きして照合
+gh api repos/actions/checkout/git/refs/tags --jq '.[] | select(.ref | test("refs/tags/v5\\.")) | .ref + " -> " + .object.sha'
+
+# または git ls-remote（GitHub アカウント不要）
+git ls-remote https://github.com/actions/checkout refs/tags/v5.0.1
+```
+
+GitHub UI: `https://github.com/{owner}/{repo}/releases/tag/{version}`
+
+### deploy.yml での書き方
+
+バージョンとリリース URL をコメントで明記して根拠を残す。
+
+```yaml
+- uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1 https://github.com/actions/checkout/releases/tag/v5.0.1
+```
+
+Dependabot を有効にしておくと、ハッシュ指定でも新バージョンが出たときに自動でPRを作ってくれる（コメントのバージョン番号を手がかりに検出する）。
+
+### pinact を使った自動化
+
+手動取得は順序の入れ違いなどミスが起きやすい。[pinact](https://github.com/suzuki-shunsuke/pinact) を使うと同じ GitHub API をツールが叩いてくれるので、ミスなく自動でハッシュ固定できる。
+
+```bash
+brew install pinact
+
+# タグ指定をハッシュに一括変換（ワークフローファイルを直接書き換える）
+pinact run
+
+# 既存のSHAとコメントのバージョンが一致しているか検証
+pinact run --verify
+
+# ハッシュ未固定のアクションがないか確認（ファイルは変更しない）
+pinact run --check
+```
+
+`--verify` と `--check` がどちらも exit 0（出力なし）であれば問題なし。
+
+#### pinact の仕組み
+
+内部では GitHub REST API（`ListTags` / `GetCommit` / `ListReleases`）を使って、タグ名からコミットSHAを解決している。手動で `gh api repos/{owner}/{repo}/commits/{tag} --jq '.sha'` を叩くのと本質的に同じだが、ワークフローファイルの解析・書き換えまで自動でやってくれる。
+
+#### ハッシュ固定の限界
+
+ハッシュ固定で防げるのは「タグの書き換えによる攻撃」のみ。**タグが最初から悪意のあるコミットを指している場合（tj-actions事件のようなケース）は防げない。** これは「信頼した時点のコードを固定する」という意味であり、そのアクションのメンテナを信頼するかどうかの判断とは別の話。
+
+参考: [GitHub Actions のセキュリティ強化 - pinact を使ったハッシュ固定](https://zenn.dev/kou_pg_0131/articles/gha-should-be-pinned)


### PR DESCRIPTION
## 概要

Closes #6

GitHub Actions ランナーが 2026年6月2日よりデフォルトで Node.js 24 を使用開始するため、`deploy.yml` の各アクションを更新し廃止警告を解消する。
併せて、サプライチェーン攻撃対策としてタグ指定をコミットハッシュ固定に変更した。

## 変更内容

### deploy.yml

| アクション | 変更前 | 変更後 |
|---|---|---|
| `actions/checkout` | `v4` | `v5.0.1`（ハッシュ固定） |
| `actions/setup-node` | `v4` | `v5.0.0`（ハッシュ固定） |
| `node-version` | `'20'` | `'22'`（現行 LTS、Node 20 は 2026年4月 EOL） |
| `actions/upload-pages-artifact` | `v3` | `v4.0.0`（ハッシュ固定） |
| `actions/deploy-pages` | `v4` | `v5.0.0`（ハッシュ固定） |

タグは mutable なためサプライチェーン攻撃のリスクがある。コミットハッシュ固定にすることで、タグの書き換えによる影響を排除した。各ハッシュはコメントにバージョンとリリース URL を記載し根拠を明示している。ハッシュの正しさは [pinact](https://github.com/suzuki-shunsuke/pinact) で検証済み（`pinact run --verify` と `pinact run --check` が exit 0）。

### KNOWLEDGE.md（新規）

GHA コミットハッシュ固定に関する知見を記録。手動での SHA 取得手順・注意点・pinact による自動化・ハッシュ固定の限界について。

## 調査メモ

- `checkout v4→v5`: Node ランタイム更新のみ、機能的な breaking changes なし
- `setup-node v4→v5`: `package.json` の `packageManager` フィールドがあると自動キャッシュが有効になるが、emoemo には当該フィールドなし・`cache: 'npm'` 明示指定済みのため影響なし
- runner 要件 (v2.327.1+) は GitHub.com では満たしている
- `node-version: '22'` は Vite の要件 (Node 18+) を満たしている

## 確認事項

- [ ] 廃止警告が解消されること
- [ ] デプロイが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)