### PR TITLE
Dependabot を追加: GitHub Actions の週次バージョン更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## 概要

GitHub Actions アクションのバージョン更新を Dependabot で自動追跡する。

## 内容

`.github/dependabot.yml` を追加。

- 対象: `github-actions`（npm は対象外）
- スケジュール: 週次
- Dependabot が新バージョンを検出すると、コミットハッシュとコメントのバージョン番号を更新するPRを自動で作成する

## npm を対象外にした理由

依存パッケージの自動更新は手動管理方針のため。脆弱性は GitHub Security alerts で検知する。

## 参考

- [Keeping your actions up to date with Dependabot - GitHub Docs](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)