### PR TITLE
.gitignore: 個人設定ファイルを除外に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ dist-ssr
 
 # Playwright CLI artifacts (screenshots, downloads, snapshots)
 .playwright-cli
+
+# Personal/local config
+.npmrc
+.claude


### PR DESCRIPTION
## 概要

ローカル環境の個人設定ファイルを `.gitignore` に追加する。

## 変更内容

- `.npmrc`: Takumi Guard 等のローカル設定が誤ってコミットされないよう除外
- `.claude`: Claude Code のセッション情報を除外

> [!NOTE]
> `emoemo/.npmrc`（Takumi Guard の registry 設定）は既にコミット済みのため引き続き追跡される。新たに追加される `.npmrc` のみ無視対象となる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)