### PR TITLE
fix: favicon のパス重複を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         }
       }
     </script>
-    <link rel="icon" type="image/png" href="%BASE_URL%favicon.png" />
+    <link rel="icon" type="image/png" href="./favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hachi+Maru+Pop&family=M+PLUS+Rounded+1c:wght@400;700&family=Mochiy+Pop+One&family=Noto+Sans+JP:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Zen+Kaku+Gothic+New:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- `%BASE_URL%favicon.png` が Vite で `/emoemo/` に展開された後、さらに base が prepend されて `/emoemo/emoemo/favicon.png` に解決されていた
- 相対パス `./favicon.png` に変更し、dev/本番ともに正しく `/emoemo/favicon.png` を指すようにする
- 結果、タブの favicon が Vite デフォルトのままになっていた問題が解消

## Test plan
- [ ] `npm run dev` → `http://localhost:5173/emoemo/` で favicon がチキンアイコンになっていること
- [ ] ビルド後 `npm run preview` でも同様にチキンアイコンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)