### PR TITLE
おまかせボタン追加（Cloudflare Workers AI 連携）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_AUTO_STYLE_ENDPOINT=https://emoemo-proxy.example.workers.dev

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_AUTO_STYLE_ENDPOINT=https://emoemo-proxy.nibuno.workers.dev

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ dist-ssr
 # Personal/local config
 .npmrc
 .claude
+
+# Env files (keep .env.example and .env.production tracked; VITE_* are public by design)
+.env
+.env.local

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 import SettingsPanel from "./components/SettingsPanel";
 import PreviewGrid from "./components/PreviewGrid";
 import { renderTextToCanvas } from "./utils/textRenderer";
+import { useAutoStyle } from "./hooks/useAutoStyle";
 
 export const COLOR_OPTIONS = [
   { value: '#000000', label: '黒' },
@@ -33,6 +34,7 @@ function App() {
   const [text, setText] = useState("");
   const [textColor, setTextColor] = useState('#000000');
   const [selectedFontIndex, setSelectedFontIndex] = useState(0);
+  const { suggest, status: autoStyleStatus, error: autoStyleError } = useAutoStyle();
   const logoRef = useRef<HTMLHeadingElement>(null);
   const animIndexRef = useRef(0);
   const clickCountRef = useRef(0);
@@ -94,6 +96,14 @@ function App() {
     logoRef.current?.animate(keyframes, options);
   }, [playEscapeAnimation]);
 
+  const handleSurprise = useCallback(async () => {
+    if (!text.trim()) return;
+    const result = await suggest(text);
+    if (!result) return;
+    setTextColor(COLOR_OPTIONS[result.colorIndex].value);
+    setSelectedFontIndex(result.fontIndex);
+  }, [text, suggest]);
+
   const handleDownload = useCallback(() => {
     if (!text.trim()) return;
 
@@ -152,6 +162,9 @@ function App() {
           colorOptions={COLOR_OPTIONS}
           onTextChange={setText}
           onColorChange={setTextColor}
+          onSurprise={handleSurprise}
+          surpriseLoading={autoStyleStatus === "loading"}
+          surpriseError={autoStyleError}
         />
 
         {/* フォントプレビュー */}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -9,6 +9,9 @@ interface SettingsPanelProps {
   colorOptions: readonly ColorOption[];
   onTextChange: (text: string) => void;
   onColorChange: (color: string) => void;
+  onSurprise: () => void;
+  surpriseLoading: boolean;
+  surpriseError: string | null;
 }
 
 function SettingsPanel({
@@ -17,7 +20,12 @@ function SettingsPanel({
   colorOptions,
   onTextChange,
   onColorChange,
+  onSurprise,
+  surpriseLoading,
+  surpriseError,
 }: SettingsPanelProps) {
+  const surpriseDisabled = !text.trim() || surpriseLoading;
+
   return (
     <div className="flex flex-col gap-6">
 
@@ -35,6 +43,34 @@ function SettingsPanel({
             focus:ring-2 focus:ring-gray-400 focus:border-transparent
             resize-none"
         />
+
+        {/* おまかせボタン */}
+        <button
+          onClick={onSurprise}
+          disabled={surpriseDisabled}
+          className={`
+            mt-2 w-full px-4 py-2 rounded-lg text-sm font-semibold
+            flex items-center justify-center gap-2 transition-colors
+            ${surpriseDisabled
+              ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
+              : 'bg-gray-900 text-white hover:bg-gray-700 active:scale-[0.99]'}
+          `}
+        >
+          {surpriseLoading ? (
+            <>
+              <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeOpacity="0.25" strokeWidth="4" />
+                <path d="M22 12a10 10 0 0 1-10 10" stroke="currentColor" strokeWidth="4" strokeLinecap="round" />
+              </svg>
+              考え中...
+            </>
+          ) : (
+            <>🎲 おまかせ</>
+          )}
+        </button>
+        {surpriseError && (
+          <p className="mt-1 text-xs text-red-600">{surpriseError}</p>
+        )}
       </div>
 
       {/* 文字色 */}

--- a/src/hooks/useAutoStyle.ts
+++ b/src/hooks/useAutoStyle.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchAutoStyle, type AutoStyleResult } from "../utils/autoStyle";
+
+type Status = "idle" | "loading" | "error";
+
+export function useAutoStyle() {
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, []);
+
+  const suggest = useCallback(async (text: string): Promise<AutoStyleResult | null> => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    setStatus("loading");
+    setError(null);
+
+    try {
+      const result = await fetchAutoStyle(text, controller.signal);
+      if (controller.signal.aborted) return null;
+      setStatus("idle");
+      return result;
+    } catch (err) {
+      if (controller.signal.aborted) return null;
+      setStatus("error");
+      setError("うまく選べませんでした。もう一度試してね");
+      console.error(err);
+      return null;
+    }
+  }, []);
+
+  return { suggest, status, error };
+}

--- a/src/utils/autoStyle.ts
+++ b/src/utils/autoStyle.ts
@@ -1,0 +1,61 @@
+export type AutoStyleResult = {
+  colorIndex: number;
+  fontIndex: number;
+  reason?: string;
+};
+
+const TIMEOUT_MS = 15_000;
+
+function isIntInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= min && value <= max;
+}
+
+export async function fetchAutoStyle(
+  text: string,
+  signal?: AbortSignal,
+): Promise<AutoStyleResult> {
+  const endpoint = import.meta.env.VITE_AUTO_STYLE_ENDPOINT;
+  if (!endpoint) {
+    throw new Error("VITE_AUTO_STYLE_ENDPOINT is not set");
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  const onExternalAbort = () => controller.abort();
+  signal?.addEventListener("abort", onExternalAbort);
+
+  try {
+    const res = await fetch(`${endpoint.replace(/\/$/, "")}/suggest`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      throw new Error(`AutoStyle endpoint returned ${res.status}`);
+    }
+
+    const data: unknown = await res.json();
+    if (!data || typeof data !== "object") {
+      throw new Error("Invalid response shape");
+    }
+
+    const obj = data as Record<string, unknown>;
+    if (!isIntInRange(obj.colorIndex, 0, 9) || !isIntInRange(obj.fontIndex, 0, 5)) {
+      throw new Error("Invalid index in response");
+    }
+
+    const result: AutoStyleResult = {
+      colorIndex: obj.colorIndex,
+      fontIndex: obj.fontIndex,
+    };
+    if (typeof obj.reason === "string") {
+      result.reason = obj.reason;
+    }
+    return result;
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", onExternalAbort);
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_AUTO_STYLE_ENDPOINT: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- テキストから文字色とフォントを自動で選ぶ「おまかせ」ボタンを追加
- バックエンドは別リポジトリ [emoemo-proxy](https://emoemo-proxy.nibuno.workers.dev) で、Cloudflare Workers AI（Llama 3.1 8B）を呼ぶ薄いプロキシ
- 15 秒タイムアウト、連打時は直前リクエストを abort、LLM 出力がぶれた時はランダムフォールバック
- Workers 側は `ALLOWED_ORIGINS` で github.io と localhost のみホワイトリスト

## 構成
```
ブラウザ (nibuno.github.io/emoemo)
  ↓ POST /suggest { text }
Cloudflare Workers (emoemo-proxy)
  ↓ env.AI.run("@cf/meta/llama-3.1-8b-instruct", ...)
Workers AI
  ↓ { colorIndex, fontIndex, reason }
```

## セキュリティ／コスト
- Workers URL は公開 URL（バンドルに焼き込まれる前提）。`VITE_AUTO_STYLE_ENDPOINT` は `.env.production` にコミット
- Cloudflare Free プラン維持、クレカ未登録のため超過しても請求発生せず停止のみ
- L3/L4 DDoS は Cloudflare 自動対応、L7 濫用対策（rate limit）は今後の TODO

## Test plan
- [x] ローカル (\`npm run dev\`) で「🎲 おまかせ」ボタン動作確認済み
- [x] Workers エンドポイントに curl で疎通確認済み（\`祝\` → 黄緑・明朝体 など）
- [x] CORS preflight / allowed origin / disallowed origin の挙動確認済み
- [ ] マージ後、本番 (nibuno.github.io/emoemo) で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)