### PR TITLE
SEO: Google サイト名を「emoemo」に表示させる

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,11 @@
     <title>emoemo - かんたんemojiメーカー</title>
     <meta name="description" content="かんたんemojiメーカー。SlackやDiscordで使えるカスタム絵文字をブラウザで作成できます。" />
 
+    <!-- アプリ名 (Google サイト名抽出のヒント) -->
+    <meta name="application-name" content="emoemo" />
+
     <!-- OGP -->
+    <meta property="og:site_name" content="emoemo" />
     <meta property="og:title" content="emoemo - かんたんemojiメーカー" />
     <meta property="og:description" content="SlackやDiscordで使えるカスタム絵文字をブラウザで作成できます。" />
     <meta property="og:type" content="website" />
@@ -26,6 +30,15 @@
     <link rel="canonical" href="https://nibuno.github.io/emoemo/" />
 
     <!-- 構造化データ -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "emoemo",
+        "alternateName": "かんたんemojiメーカー",
+        "url": "https://nibuno.github.io/emoemo/"
+      }
+    </script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",


### PR DESCRIPTION
## Background

Google 検索結果で emoemo のサイト名が **「GitHub Pages documentation」** と表示されてしまっている。比較例として MEGAMOJI は **「zk-phi」**（GitHub ユーザー名）と正しく出ている。

これは Google が拾うサイト名シグナルが現状不足しているのが原因。

## Changes

\`index.html\` に 3 種類のサイト名シグナルを追加:

1. \`<meta property="og:site_name" content="emoemo" />\`
2. \`<meta name="application-name" content="emoemo" />\`
3. **WebSite 型の JSON-LD** を WebApplication と並列で追加（Google のサイト名抽出は \`WebSite\` schema を優先するため、\`WebApplication\` だけだと弱い）

## 反映タイミング

Google の再クロール待ち（数日〜2 週間）。マージ後 [Search Console](https://search.google.com/search-console) で対象 URL を「URL 検査」→「インデックス登録をリクエスト」すると早まる。

## Test plan
- [x] \`npm run build\` 通過
- [x] dist/index.html に追加メタタグが含まれることを確認
- [ ] マージ後デプロイ → Search Console でリクロール依頼
- [ ] 数日後、\`emoemo slack emoji\` 検索でサイト名が「emoemo」に変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)