### PR TITLE
Cloudflare Web Analytics を導入

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Hachi+Maru+Pop&family=M+PLUS+Rounded+1c:wght@400;700&family=Mochiy+Pop+One&family=Noto+Sans+JP:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Zen+Kaku+Gothic+New:wght@400;700&display=swap" rel="stylesheet">
+
+    <!-- Cloudflare Web Analytics (トークンは公開情報) -->
+    <script type='module' src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "9173577483664098a8828b9d0c498954"}'></script>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
## 概要

Cookieレスのアクセス解析として Cloudflare Web Analytics のビーコンスニペットを `index.html` に追加しました。

Closes #24

## 変更内容

- `index.html` の `</head>` 直前にビーコンの `<script>` タグを追加（3行）
- トークンは HTML に埋め込まれる公開情報のためそのままコミット

## 確認したこと

- `npm run build` が成功し、`dist/index.html` にビーコンタグが含まれることを確認

## マージ後の確認手順

1. GitHub Pages へのデプロイ完了を待つ
2. https://nibuno.github.io/emoemo/ にアクセス
3. Cloudflare ダッシュボード（Web分析）に PV が記録されることを確認（反映まで数分かかることあり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)